### PR TITLE
Add get_commitment_proof

### DIFF
--- a/libzeropool-rs-node/index.d.ts
+++ b/libzeropool-rs-node/index.d.ts
@@ -2,8 +2,10 @@ declare class MerkleTree {
     constructor(path: string);
 
     getRoot(): string
-    addHash(index: BigInt, hash: Buffer): void;
-    getProof(index: BigInt): MerkleProof;
+    addHash(index: number, hash: Buffer): void;
+    appendHash(hash: Buffer): number;
+    getProof(index: number): MerkleProof;
+    getCommitmentProof(index: number): MerkleProof;
 }
 
 declare class TxStorage {

--- a/libzeropool-rs-node/index.js
+++ b/libzeropool-rs-node/index.js
@@ -13,8 +13,16 @@ class MerkleTree {
         zp.merkleAddHash(this.inner, index, hash);
     }
 
+    appendHash(hash) {
+        return zp.merkleAppendHash(this.inner, hash);
+    }
+
     getProof(index) {
         return zp.merkleGetProof(this.inner, index);
+    }
+
+    getCommitmentProof(index) {
+        return zp.merkleGetCommitmentProof(this.inner, index)
     }
 }
 

--- a/libzeropool-rs-node/src/lib.rs
+++ b/libzeropool-rs-node/src/lib.rs
@@ -26,7 +26,9 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("merkleNew", merkle::merkle_new)?;
     cx.export_function("merkleGetRoot", merkle::merkle_get_root)?;
     cx.export_function("merkleAddHash", merkle::merkle_add_hash)?;
-    cx.export_function("merkleGetProof", merkle::merkle_get_proof)?;
+    cx.export_function("merkleAppendHash", merkle::merkle_append_hash)?;
+    cx.export_function("merkleGetProof", merkle::merkle_get_leaf_proof)?;
+    cx.export_function("merkleGetCommitmentProof", merkle::merkle_get_commitment_proof)?;
 
     cx.export_function("txStorageNew", storage::tx_storage_new)?;
     cx.export_function("txStorageAdd", storage::tx_storage_add)?;

--- a/libzeropool-rs/src/client/mod.rs
+++ b/libzeropool-rs/src/client/mod.rs
@@ -310,7 +310,7 @@ where
             .iter()
             .copied()
             .map(|(index, _note)| {
-                tree.get_proof(index)
+                tree.get_leaf_proof(index)
                     .ok_or_else(|| CreateTxError::ProofNotFound(index))
             })
             .chain((0..).map(|_| Ok(zero_proof())))
@@ -320,7 +320,7 @@ where
         let secret = TransferSec::<P::Fr> {
             tx,
             in_proof: (
-                tree.get_proof(state.latest_account_index)
+                tree.get_leaf_proof(state.latest_account_index)
                     .unwrap_or_else(zero_proof),
                 note_proofs,
             ),
@@ -359,7 +359,7 @@ where
         &self,
         index: u64,
     ) -> Option<MerkleProof<P::Fr, { constants::HEIGHT }>> {
-        self.state.borrow().tree.get_proof(index)
+        self.state.borrow().tree.get_leaf_proof(index)
     }
 
     pub fn get_merkle_proof_for_new<I>(


### PR DESCRIPTION
1. Add `appendHash` binding
2. Rename `get_proof` to `get_leaf_proof`
3. Add `get_proof_unchecked` (doesn't check the presence of node in db) and test for it
4. Add neon binding for getting Merkle proof for commitment hashes at height `OUTLOG` using `get_proof_unchecked`