### PR TITLE
Fix create_tx

### DIFF
--- a/libzeropool-rs/src/client/state.rs
+++ b/libzeropool-rs/src/client/state.rs
@@ -78,13 +78,13 @@ where
         for (index, tx) in txs.iter() {
             match tx {
                 Transaction::Account(acc) => {
-                    if index > latest_account_index {
+                    if index >= latest_account_index {
                         latest_account_index = index;
                         latest_account = Some(acc);
                     }
                 }
                 Transaction::Note(_) => {
-                    if index > latest_note_index {
+                    if index >= latest_note_index {
                         latest_note_index = index;
                     }
                 }

--- a/libzeropool-rs/src/sparse_array.rs
+++ b/libzeropool-rs/src/sparse_array.rs
@@ -26,7 +26,7 @@ where
     T: BorshSerialize + BorshDeserialize,
 {
     pub async fn new_web(name: &str) -> SparseArray<WebDatabase, T> {
-        let db = WebDatabase::open(name.to_owned(), 0).await.unwrap();
+        let db = WebDatabase::open(name.to_owned(), 1).await.unwrap();
 
         SparseArray {
             db,


### PR DESCRIPTION
Fixes for correct transfer circuit verification:
1. Nullifier should be calculated from `in_account_hash`
2. `input_hashes` should be vec of length `IN+1` (previously was just `IN`)
3. Input dummy notes should have diversified public key derived from account eta
4. Now it is possible to add an account and note with zero indexes to the state