### PR TITLE
Fix delta index

### DIFF
--- a/libzeropool-rs/src/client/mod.rs
+++ b/libzeropool-rs/src/client/mod.rs
@@ -316,10 +316,10 @@ where
             let data_size = data.as_ref().map(|d| d.len()).unwrap_or(0);
             Vec::with_capacity(ciphertext_size + data_size)
         };
-        memo_data.extend(&ciphertext);
         if let Some(data) = &mut data {
             memo_data.append(data);
         }
+        memo_data.extend(&ciphertext);
 
         let memo_hash = keccak256(&memo_data);
         let memo = Num::from_uint_reduced(NumRepr(Uint::from_big_endian(&memo_hash)));

--- a/libzeropool-rs/src/client/mod.rs
+++ b/libzeropool-rs/src/client/mod.rs
@@ -43,8 +43,8 @@ pub enum CreateTxError {
     ProofNotFound(u64),
     #[error("Failed to parse address: {0}")]
     AddressParseError(#[from] AddressParseError),
-    #[error("Insufficient balance: sum of outputs is greater than sum of inputs")]
-    InsufficientBalance,
+    #[error("Insufficient balance: sum of outputs is greater than sum of inputs: {0} > {1}")]
+    InsufficientBalance(String, String),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -146,7 +146,7 @@ where
         let state = &self.state;
 
         let prev_account = state.latest_account.unwrap_or_else(|| Account {
-            eta: Num::ZERO,
+            eta: keys.eta,
             i: BoundedNum::new(Num::ZERO),
             b: BoundedNum::new(Num::ZERO),
             e: BoundedNum::new(Num::ZERO),
@@ -223,7 +223,10 @@ where
                 if input_value.to_uint() >= output_value.to_uint() {
                     input_value - output_value
                 } else {
-                    return Err(CreateTxError::InsufficientBalance);
+                    return Err(CreateTxError::InsufficientBalance(
+                        output_value.to_string(),
+                        input_value.to_string(),
+                    ));
                 }
             }
             TxType::Withdraw(amount) => {
@@ -231,7 +234,10 @@ where
                 if input_value.to_uint() + delta_value.to_uint() >= NumRepr::ZERO {
                     input_value + delta_value
                 } else {
-                    return Err(CreateTxError::InsufficientBalance);
+                    return Err(CreateTxError::InsufficientBalance(
+                        delta_value.to_string(),
+                        input_value.to_string(),
+                    ));
                 }
             }
             TxType::Deposit(amount) => {
@@ -264,7 +270,7 @@ where
 
         // Hash input account + notes filling remaining space with non-hashed zeroes
         let owned_zero_notes = (0..).map(|_| {
-            let d:BoundedNum<_, {constants::DIVERSIFIER_SIZE_BITS}> = rng.gen();
+            let d: BoundedNum<_, { constants::DIVERSIFIER_SIZE_BITS }> = rng.gen();
             let p_d = derive_key_p_d::<P, P::Fr>(d.to_num(), keys.eta, &self.params).x;
             Note {
                 d,
@@ -299,21 +305,21 @@ where
         let out_commit = out_commitment_hash(out_hashes.as_slice(), &self.params);
         let tx_hash = tx_hash(input_hashes.as_slice(), out_commit, &self.params);
 
-        let delta = make_delta::<P::Fr>(
-            delta_value,
-            input_energy,
-            Num::from(spend_interval_index as u64),
-        );
+        let delta_index = (state.latest_account_index / 128) * 128;
+        let delta = make_delta::<P::Fr>(delta_value, input_energy, Num::from(delta_index));
 
         let tree = &state.tree;
         let root: Num<P::Fr> = tree.get_root();
 
-        let mut memo_data =
-            Vec::with_capacity(data.as_ref().map(|d| d.len()).unwrap_or(0) + ciphertext.len());
+        let mut memo_data = {
+            let ciphertext_size = ciphertext.len();
+            let data_size = data.as_ref().map(|d| d.len()).unwrap_or(0);
+            Vec::with_capacity(ciphertext_size + data_size)
+        };
+        memo_data.extend(&ciphertext);
         if let Some(data) = &mut data {
             memo_data.append(data);
         }
-        memo_data.extend(&ciphertext);
 
         let memo_hash = keccak256(&memo_data);
         let memo = Num::from_uint_reduced(NumRepr(Uint::from_big_endian(&memo_hash)));
@@ -327,10 +333,7 @@ where
         };
 
         let tx = Tx {
-            input: (
-                prev_account,
-                in_notes,
-            ),
+            input: (prev_account, in_notes),
             output: (out_account, out_notes),
         };
 
@@ -343,6 +346,8 @@ where
 
         let (eddsa_s, eddsa_r) = tx_sign(keys.sk, tx_hash, &self.params);
 
+        let account_proof = tree.get_leaf_proof(state.latest_account_index)
+                .unwrap_or_else(zero_proof);
         let note_proofs = in_notes_original
             .iter()
             .copied()
@@ -356,11 +361,7 @@ where
 
         let secret = TransferSec::<P::Fr> {
             tx,
-            in_proof: (
-                tree.get_leaf_proof(state.latest_account_index)
-                    .unwrap_or_else(zero_proof),
-                note_proofs,
-            ),
+            in_proof: (account_proof, note_proofs),
             eddsa_s: eddsa_s.to_other().unwrap(),
             eddsa_r,
             eddsa_a: keys.a,

--- a/libzeropool-rs/src/client/state.rs
+++ b/libzeropool-rs/src/client/state.rs
@@ -128,7 +128,7 @@ where
         // Update merkle tree
         self.tree.add_hash(at_index, account_hash, false);
 
-        if at_index > self.latest_account_index {
+        if at_index >= self.latest_account_index {
             self.latest_account_index = at_index;
             self.latest_account = Some(account);
         }

--- a/libzeropool-rs/src/client/state.rs
+++ b/libzeropool-rs/src/client/state.rs
@@ -29,7 +29,7 @@ pub struct State<D: KeyValueDB, P: PoolParams> {
     /// Stores only usable (own) accounts and notes
     pub(crate) txs: TxStorage<D, P::Fr>,
     pub(crate) latest_account: Option<NativeAccount<P::Fr>>,
-    pub latest_account_index: u64,
+    pub latest_account_index: Option<u64>,
     /// Latest owned note index
     pub latest_note_index: u64,
     pub(crate) total_balance: BoundedNum<P::Fr, { constants::BALANCE_SIZE_BITS }>,
@@ -72,14 +72,14 @@ where
 {
     pub fn new(tree: MerkleTree<D, P>, txs: TxStorage<D, P::Fr>, params: P) -> Self {
         // TODO: Cache
-        let mut latest_account_index = 0;
+        let mut latest_account_index = None;
         let mut latest_note_index = 0;
         let mut latest_account = None;
         for (index, tx) in txs.iter() {
             match tx {
                 Transaction::Account(acc) => {
-                    if index >= latest_account_index {
-                        latest_account_index = index;
+                    if index >= latest_account_index.unwrap_or(0){
+                        latest_account_index = Some(index);
                         latest_account = Some(acc);
                     }
                 }
@@ -128,8 +128,8 @@ where
         // Update merkle tree
         self.tree.add_hash(at_index, account_hash, false);
 
-        if at_index >= self.latest_account_index {
-            self.latest_account_index = at_index;
+        if at_index >= self.latest_account_index.unwrap_or(0) {
+            self.latest_account_index = Some(at_index);
             self.latest_account = Some(account);
         }
 


### PR DESCRIPTION
1. Delta index should be the index of the leftmost empty leaf
2. Use keys' eta  for a default dummy account 
3. Convert delta parameters from `Num` to `(i64, i64, u64)` in node version
4. Add parameters for `InsufficientBalance` error to improve logging