### PR TITLE
Fix delta energy

### DIFF
--- a/libzeropool-rs-node/index.d.ts
+++ b/libzeropool-rs-node/index.d.ts
@@ -15,6 +15,7 @@ declare class MerkleTree {
     appendHash(hash: Buffer): number;
     getProof(index: number): MerkleProof;
     getCommitmentProof(index: number): MerkleProof;
+    getAllNodes(): any;
 }
 
 declare class TxStorage {

--- a/libzeropool-rs-node/index.js
+++ b/libzeropool-rs-node/index.js
@@ -32,6 +32,10 @@ class MerkleTree {
     getCommitmentProof(index) {
         return zp.merkleGetCommitmentProof(this.inner, index)
     }
+
+    getAllNodes() {
+        return zp.merkleGetAllNodes(this.inner)
+    }
 }
 
 class TxStorage {

--- a/libzeropool-rs-node/src/lib.rs
+++ b/libzeropool-rs-node/src/lib.rs
@@ -53,6 +53,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("merkleAppendHash", merkle::merkle_append_hash)?;
     cx.export_function("merkleGetProof", merkle::merkle_get_leaf_proof)?;
     cx.export_function("merkleGetCommitmentProof", merkle::merkle_get_commitment_proof)?;
+    cx.export_function("merkleGetAllNodes", merkle::merkle_get_all_nodes)?;
 
     cx.export_function("txStorageNew", storage::tx_storage_new)?;
     cx.export_function("txStorageAdd", storage::tx_storage_add)?;

--- a/libzeropool-rs-node/src/merkle.rs
+++ b/libzeropool-rs-node/src/merkle.rs
@@ -133,3 +133,18 @@ pub fn merkle_get_next_index(mut cx: FunctionContext) -> JsResult<JsValue> {
 
     Ok(result)
 }
+
+pub fn merkle_get_all_nodes(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let tree = cx.argument::<BoxedMerkleTree>(0)?;
+
+    let nodes: Vec<(u64, u32)> = tree.
+        borrow().
+        inner.get_all_nodes()
+        .iter()
+        .map(|n| (n.index, n.height))
+        .collect();
+
+    let result = neon_serde::to_value(&mut cx, &nodes).unwrap();
+
+    Ok(result)
+}

--- a/libzeropool-rs-wasm/src/client/mod.rs
+++ b/libzeropool-rs-wasm/src/client/mod.rs
@@ -229,6 +229,14 @@ impl UserAccount {
         Ok(())
     }
 
+    #[wasm_bindgen(js_name = "getRoot")]
+    /// Get root
+    pub fn get_root(&mut self) -> String {
+        let root = self.inner.borrow_mut().state.tree.get_root().to_string();
+
+        root
+    }
+
     #[wasm_bindgen(js_name = "addReceivedNote")]
     /// Caches a note at specified index.
     /// Only cache received notes.


### PR DESCRIPTION
1. Fix energy counting for out account:
`delta_energy` should be zero for deposit and transfer.
For withdrawals, it must be <= 0. For now, by default, all energy is withdrawn with a specified token amount, but it may be changed later so that the user can specify how much energy he wants to withdraw, similarly to the `delta_index` parameter
2. `spend_interval_index` should be greater than the index of the latest note, according to the circuit
3. `add_received_note` now does not replace already existing leaves to prevent incorrect balance counting
4. Add some bindings for client libraries