### PR TITLE
Feature/tx types

### DIFF
--- a/libzeropool-rs-wasm/src/client/tx_types.rs
+++ b/libzeropool-rs-wasm/src/client/tx_types.rs
@@ -1,0 +1,108 @@
+use crate::{Fr, IDepositData, ITransferData, IWithdrawData};
+use libzeropool_rs::client::{TokenAmount, TxOutput, TxType as NativeTxType};
+use serde::Deserialize;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub enum TxType {
+    Transfer = "transfer",
+    Deposit = "deposit",
+    Withdraw = "withdraw",
+}
+
+pub trait JsTxType {
+    fn to_native(&self) -> Result<NativeTxType<Fr>, JsValue>;
+}
+
+#[wasm_bindgen]
+#[derive(Deserialize)]
+pub struct TxBaseFields {
+    fee: TokenAmount<Fr>,
+    data: Option<Vec<u8>>,
+}
+
+#[wasm_bindgen]
+#[derive(Deserialize)]
+pub struct DepositData {
+    base_fields: TxBaseFields,
+    amount: TokenAmount<Fr>,
+}
+
+impl JsTxType for IDepositData {
+    fn to_native(&self) -> Result<NativeTxType<Fr>, JsValue> {
+        let DepositData {
+            base_fields,
+            amount,
+        } = serde_wasm_bindgen::from_value(self.into())?;
+
+        Ok(NativeTxType::Deposit(
+            base_fields.fee,
+            base_fields.data.unwrap_or(vec![]),
+            amount,
+        ))
+    }
+}
+
+#[derive(Deserialize)]
+struct Output {
+    to: String,
+    amount: TokenAmount<Fr>,
+}
+
+#[wasm_bindgen]
+#[derive(Deserialize)]
+pub struct TransferData {
+    base_fields: TxBaseFields,
+    outputs: Vec<Output>,
+}
+
+impl JsTxType for ITransferData {
+    fn to_native(&self) -> Result<NativeTxType<Fr>, JsValue> {
+        let TransferData {
+            base_fields,
+            outputs,
+        } = serde_wasm_bindgen::from_value(self.into())?;
+
+        let outputs = outputs
+            .into_iter()
+            .map(|out| TxOutput {
+                to: out.to,
+                amount: out.amount,
+            })
+            .collect::<Vec<_>>();
+
+        Ok(NativeTxType::Transfer(
+            base_fields.fee,
+            base_fields.data.unwrap_or(vec![]),
+            outputs,
+        ))
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Deserialize)]
+pub struct WithdrawData {
+    base_fields: TxBaseFields,
+    amount: TokenAmount<Fr>,
+    to: String,
+    native_amount: TokenAmount<Fr>,
+}
+
+impl JsTxType for IWithdrawData {
+    fn to_native(&self) -> Result<NativeTxType<Fr>, JsValue> {
+        let WithdrawData {
+            base_fields,
+            amount,
+            to,
+            native_amount,
+        } = serde_wasm_bindgen::from_value(self.into())?;
+
+        Ok(NativeTxType::Withdraw(
+            base_fields.fee,
+            base_fields.data.unwrap_or(vec![]),
+            amount,
+            to,
+            native_amount,
+        ))
+    }
+}

--- a/libzeropool-rs-wasm/src/client/tx_types.rs
+++ b/libzeropool-rs-wasm/src/client/tx_types.rs
@@ -86,6 +86,7 @@ pub struct WithdrawData {
     amount: TokenAmount<Fr>,
     to: Vec<u8>,
     native_amount: TokenAmount<Fr>,
+    energy_amount: TokenAmount<Fr>,
 }
 
 impl JsTxType for IWithdrawData {
@@ -95,6 +96,7 @@ impl JsTxType for IWithdrawData {
             amount,
             to,
             native_amount,
+            energy_amount,
         } = serde_wasm_bindgen::from_value(self.into())?;
 
         Ok(NativeTxType::Withdraw(
@@ -103,6 +105,7 @@ impl JsTxType for IWithdrawData {
             amount,
             to,
             native_amount,
+            energy_amount,
         ))
     }
 }

--- a/libzeropool-rs-wasm/src/client/tx_types.rs
+++ b/libzeropool-rs-wasm/src/client/tx_types.rs
@@ -84,7 +84,7 @@ impl JsTxType for ITransferData {
 pub struct WithdrawData {
     base_fields: TxBaseFields,
     amount: TokenAmount<Fr>,
-    to: String,
+    to: Vec<u8>,
     native_amount: TokenAmount<Fr>,
 }
 

--- a/libzeropool-rs-wasm/src/ts_types.rs
+++ b/libzeropool-rs-wasm/src/ts_types.rs
@@ -98,6 +98,29 @@ export interface VK {
     delta: string[][]; // G2
     ic: string[][];    // G1[]
 }
+
+export interface ITxBaseFields {
+    fee: string;
+    data: Uint8Array;
+}
+
+export interface IDepositData {
+    base_fields: ITxBaseFields;
+    amount: string;
+}
+
+export interface ITransferData {
+    base_fields: ITxBaseFields;
+    outputs: Output[];
+}
+
+export interface IWithdrawData {
+    base_fields: ITxBaseFields;
+    amount: string;
+    to: string;
+    native_amount: string;
+}
+
 "#;
 
 #[wasm_bindgen]
@@ -167,6 +190,15 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "Array<Uint8Array>")]
     pub type RawHashes;
+
+    #[wasm_bindgen(typescript_type = "IDepositData")]
+    pub type IDepositData;
+
+    #[wasm_bindgen(typescript_type = "ITransferData")]
+    pub type ITransferData;
+
+    #[wasm_bindgen(typescript_type = "IWithdrawData")]
+    pub type IWithdrawData;
 }
 
 #[derive(Serialize, Deserialize)]

--- a/libzeropool-rs-wasm/src/ts_types.rs
+++ b/libzeropool-rs-wasm/src/ts_types.rs
@@ -119,6 +119,7 @@ export interface IWithdrawData {
     amount: string;
     to: Uint8Array;
     native_amount: string;
+    energy_amount: string;
 }
 
 "#;

--- a/libzeropool-rs-wasm/src/ts_types.rs
+++ b/libzeropool-rs-wasm/src/ts_types.rs
@@ -117,7 +117,7 @@ export interface ITransferData {
 export interface IWithdrawData {
     base_fields: ITxBaseFields;
     amount: string;
-    to: string;
+    to: Uint8Array;
     native_amount: string;
 }
 


### PR DESCRIPTION
1. Extract js wrapper types into a separate file. Each type implements the `JsTxType` trait with the `to_native` method for conversion into a rust struct.
2. Add ts types for each struct
3. Subtract fee from initial `delta_value`
4. Add user user-defined value for energy withdrawal