### PR TITLE
Fix next_index after add hash

### DIFF
--- a/libzeropool-rs/src/client/mod.rs
+++ b/libzeropool-rs/src/client/mod.rs
@@ -356,8 +356,6 @@ where
             .chain(out_note_hashes)
             .collect();
 
-        let commitment_root = out_commitment_hash(out_hashes.as_slice(), &self.params);
-
         let out_commit = out_commitment_hash(out_hashes.as_slice(), &self.params);
         let tx_hash = tx_hash(input_hashes.as_slice(), out_commit, &self.params);
 
@@ -426,7 +424,7 @@ where
             secret,
             ciphertext,
             memo: memo_data,
-            commitment_root,
+            commitment_root: out_commit,
             out_hashes,
         })
     }

--- a/libzeropool-rs/src/merkle.rs
+++ b/libzeropool-rs/src/merkle.rs
@@ -102,8 +102,9 @@ impl<D: KeyValueDB, P: PoolParams> MerkleTree<D, P> {
 
         self.db.write(batch).unwrap();
 
-        if index >= self.next_index {
-            self.next_index = index + 1;
+        let next_leaf_index = u64::pow(2, height) * (index + 1);
+        if next_leaf_index >= self.next_index {
+            self.next_index = next_leaf_index;
         }
     }
 


### PR DESCRIPTION
1. Fix next_index after adding hash
2. Remove second computation of `out_commitment_hash` 