### PR TITLE
Fix transactions index issues

### DIFF
--- a/libzeropool-rs-node/Cargo.toml
+++ b/libzeropool-rs-node/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["index.node"]
 crate-type = ["cdylib"]
 
 [dependencies]
-libzeropool-rs = { version = "0.3.7", features = ["native"] }
+libzeropool-rs = { version = "0.3.8", features = ["native"] }
 neon = { version = "0.9.0", default-features = false, features = ["napi-6"] }
 # FIXME: Using a random fork for now
 neon-serde = { git = "https://github.com/brokad/neon-serde.git", rev = "0a168baf9e52b1ebe6bd4661d95efc1318d788d8" }

--- a/libzeropool-rs-wasm/Cargo.toml
+++ b/libzeropool-rs-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzeropool-rs-wasm"
 description = "A higher level zeropool API for Wasm"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zeropoolnetwork/libzeropool-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzeropool-rs-wasm/scripts/clean
+++ b/libzeropool-rs-wasm/scripts/clean
@@ -2,4 +2,4 @@
 
 PARENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 
-rm -rf $PARENT_DIR/bundler $PARENT_DIR/nodejs
+rm -rf $PARENT_DIR/bundler $PARENT_DIR/nodejs $PARENT_DIR/web

--- a/libzeropool-rs/Cargo.toml
+++ b/libzeropool-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libzeropool-rs"
 description = "A higher level zeropool API"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Dmitry Vdovin <voidxnull@gmail.com>"]
 repository = "https://github.com/zeropoolnetwork/libzeropool-rs/"
 license = "MIT OR Apache-2.0"

--- a/libzeropool-rs/src/client/mod.rs
+++ b/libzeropool-rs/src/client/mod.rs
@@ -219,11 +219,11 @@ where
                 _ => None,
             })
             .collect();
-
+        
         let spend_interval_index = in_notes_original
             .last()
             .map(|(index, _)| *index + 1)
-            .unwrap_or(state.latest_note_index);
+            .unwrap_or(if state.latest_note_index > 0 { state.latest_note_index + 1 } else { 0 });
 
         // Calculate total balance (account + constants::IN notes).
         let mut input_value = in_account.b.to_num();

--- a/libzeropool-rs/src/client/state.rs
+++ b/libzeropool-rs/src/client/state.rs
@@ -174,7 +174,7 @@ where
             .iter_slice(latest_account_index..=self.latest_note_index)
             .map(|(index, _)| index)
             .next()
-            .unwrap_or(0)
+            .unwrap_or(latest_account_index)
     }
 
     /// Returns user's total balance (account + available notes).


### PR DESCRIPTION
The pull request solves two issues which appear on transaction creation:
1. The last account has spent offset greater than the last note (i.e. there are no unspent notes). In that case the first spent notes will be collected as input.
2. There are several spent and no unspent notes. In that case the output account's index was incorrect for every new transaction

It's strongly need to review this changes!